### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,10 @@ jobs:
         working-directory: finish
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
     - run: unset _JAVA_OPTIONS
     - name: Run tests
       run: ../scripts/testApp.sh

--- a/finish/inventory/Dockerfile
+++ b/finish/inventory/Dockerfile
@@ -1,4 +1,4 @@
-FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+FROM icr.io/appcafe/open-liberty:kernel-slim-java11-openj9-ubi
 
 ARG VERSION=1.0
 ARG REVISION=SNAPSHOT
@@ -17,6 +17,6 @@ LABEL \
   description="This image contains the inventory microservice running with the Open Liberty runtime."
 
 COPY --chown=1001:0 src/main/liberty/config /config/
+RUN features.sh
 COPY --chown=1001:0 target/inventory.war /config/apps
-
 RUN configure.sh

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -30,8 +30,8 @@
         <inventory.node.port>32000</inventory.node.port>
         <!-- end::inventory-node-port[] -->
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.3</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -88,19 +88,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <cluster.ip>${cluster.ip}</cluster.ip>

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -30,8 +30,8 @@
         <inventory.node.port>32000</inventory.node.port>
         <!-- end::inventory-node-port[] -->
         <!-- Liberty configuration -->
-        <liberty.var.http.port>9080</liberty.var.http.port>
-        <liberty.var.https.port>9443</liberty.var.https.port>
+        <liberty.var.http.port>9081</liberty.var.http.port>
+        <liberty.var.https.port>9444</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -57,21 +57,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-client</artifactId>
-            <version>3.3.6</version>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-extension-providers</artifactId>
-            <version>3.3.6</version>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1.4</version>
+            <artifactId>jakarta.json</artifactId>
+            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
  // end::copyright[]
 package io.openliberty.guides.inventory;

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,8 @@
 package io.openliberty.guides.inventory;
 
 // JAX-RS
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("inventory")
 public class InventoryApplication extends Application {

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
- // end::copyright[]
+// end::copyright[]
 package io.openliberty.guides.inventory;
 
 // JAX-RS

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Properties;
 import io.openliberty.guides.inventory.model.InventoryList;
 import io.openliberty.guides.inventory.model.SystemData;
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 // tag::ApplicationScoped[]
 @ApplicationScoped

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package io.openliberty.guides.inventory;

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,15 +17,15 @@ import io.openliberty.guides.inventory.model.InventoryList;
 
 import java.util.Properties;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 
 @RequestScoped
 @Path("/systems")
@@ -45,7 +45,7 @@ public class InventoryResource {
     Properties props = systemClient.getProperties(hostname);
     if (props == null) {
       return Response.status(Response.Status.NOT_FOUND)
-                     .entity("{ \"error\" : \"Unknown hostname or the system service " 
+                     .entity("{ \"error\" : \"Unknown hostname or the system service "
                      + "may not be running on " + hostname + "\" }")
                      .build();
     }

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package io.openliberty.guides.inventory;

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -39,7 +39,8 @@ public class SystemClient {
 
   // Wrapper function that gets properties
   public Properties getProperties(String hostname) {
-    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(HTTP_PORT), SYSTEM_PROPERTIES);
+    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(HTTP_PORT),
+                          SYSTEM_PROPERTIES);
     Builder clientBuilder = buildClientBuilder(url);
     return getPropertiesHelper(clientBuilder);
   }

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -76,8 +76,8 @@ public class SystemClient {
       Builder builder = client.target(urlString).request();
       return builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     } catch (Exception e) {
-      System.err.println("Exception thrown while building the client: " +
-                         e.getMessage());
+      System.err.println("Exception thrown while building the client: "
+                         + e.getMessage());
       return null;
     }
   }
@@ -94,8 +94,8 @@ public class SystemClient {
     } catch (RuntimeException e) {
       System.err.println("Runtime exception: " + e.getMessage());
     } catch (Exception e) {
-      System.err.println("Exception thrown while invoking the request: " +
-                         e.getMessage());
+      System.err.println("Exception thrown while invoking the request: "
+                         + e.getMessage());
     }
     return null;
   }

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,15 +15,15 @@ package io.openliberty.guides.inventory.client;
 import java.net.URI;
 import java.util.Properties;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Invocation.Builder;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -35,12 +35,12 @@ public class SystemClient {
   private final String PROTOCOL = "http";
 
   @Inject
-  @ConfigProperty(name = "default.http.port")
-  String DEFAULT_PORT;
+  @ConfigProperty(name = "http.port")
+  String HTTP_PORT;
 
   // Wrapper function that gets properties
   public Properties getProperties(String hostname) {
-    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(DEFAULT_PORT), SYSTEM_PROPERTIES);
+    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(HTTP_PORT), SYSTEM_PROPERTIES);
     Builder clientBuilder = buildClientBuilder(url);
     return getPropertiesHelper(clientBuilder);
   }

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package io.openliberty.guides.inventory.client;

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -34,12 +34,12 @@ public class SystemClient {
   private final String PROTOCOL = "http";
 
   @Inject
-  @ConfigProperty(name = "http.port")
-  String HTTP_PORT;
+  @ConfigProperty(name = "system.node.port")
+  String SYS_NODE_PORT;
 
   // Wrapper function that gets properties
   public Properties getProperties(String hostname) {
-    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(HTTP_PORT),
+    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(SYS_NODE_PORT),
                           SYSTEM_PROPERTIES);
     Builder clientBuilder = buildClientBuilder(url);
     return getPropertiesHelper(clientBuilder);

--- a/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -76,7 +76,8 @@ public class SystemClient {
       Builder builder = client.target(urlString).request();
       return builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     } catch (Exception e) {
-      System.err.println("Exception thrown while building the client: " + e.getMessage());
+      System.err.println("Exception thrown while building the client: " +
+                         e.getMessage());
       return null;
     }
   }
@@ -93,7 +94,8 @@ public class SystemClient {
     } catch (RuntimeException e) {
       System.err.println("Runtime exception: " + e.getMessage());
     } catch (Exception e) {
-      System.err.println("Exception thrown while invoking the request: " + e.getMessage());
+      System.err.println("Exception thrown while invoking the request: " +
+                         e.getMessage());
     }
     return null;
   }

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -2,15 +2,15 @@
 
   <featureManager>
     <feature>jaxrs-2.1</feature>
-    <feature>jsonp-1.1</feature>
-    <feature>mpConfig-1.4</feature>
-    <feature>cdi-2.0</feature>
+    <feature>jsonp-2.1</feature>
+    <feature>mpConfig-3.1</feature>
+    <feature>cdi-4.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />
 
   <webApplication location="inventory.war" contextRoot="/"/>

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -1,14 +1,16 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-    <feature>jaxrs-2.1</feature>
+    <feature>restfulWS-3.1</feature>
     <feature>jsonp-2.1</feature>
-    <feature>mpConfig-3.1</feature>
+    <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
+    <feature>mpConfig-3.1</feature>
   </featureManager>
 
-  <variable name="http.port" defaultValue="9080"/>
-  <variable name="https.port" defaultValue="9443"/>
+  <variable name="system.node.port" defaultValue="9080"/>
+  <variable name="http.port" defaultValue="9081"/>
+  <variable name="https.port" defaultValue="9444"/>
 
   <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />

--- a/finish/inventory/src/main/webapp/index.html
+++ b/finish/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2020 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/finish/inventory/src/main/webapp/index.html
+++ b/finish/inventory/src/main/webapp/index.html
@@ -33,8 +33,9 @@
             <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 4.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#jaxrs-2.1.html" target="_blank" rel="noopener noreferrer">Java RESTful Services 2.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 2.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
         </ul>
     </p>
 </div>

--- a/finish/inventory/src/main/webapp/index.html
+++ b/finish/inventory/src/main/webapp/index.html
@@ -30,11 +30,11 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-3.3.html" target="_blank" rel="noopener noreferrer">MicroProfile 3.3</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-1.4.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 1.4</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#cdi-2.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 2.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jaxrs-2.1.html" target="_blank" rel="noopener noreferrer">Java RESTful Services 2.1</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-1.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 1.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 2.1</a></li>
         </ul>
     </p>
 </div>

--- a/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,13 +15,13 @@ package it.io.openliberty.guides.inventory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.json.JsonObject;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSession;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.json.JsonObject;
+import jakarta.net.ssl.HostnameVerifier;
+import jakarta.net.ssl.SSLSession;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
 import org.junit.jupiter.api.AfterAll;

--- a/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -117,10 +117,10 @@ public class InventoryEndpointIT {
         this.assertResponse(sysUrl, sysResponse);
 
         JsonObject jsonFromInventory = (JsonObject) invResponse
-                                                            .readEntity(JsonObject.class)
-                                                            .getJsonArray("systems")
-                                                            .getJsonObject(0)
-                                                            .get("properties");
+                                                    .readEntity(JsonObject.class)
+                                                    .getJsonArray("systems")
+                                                    .getJsonObject(0)
+                                                    .get("properties");
 
         JsonObject jsonFromSystem = sysResponse.readEntity(JsonObject.class);
 

--- a/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -14,9 +14,10 @@ package it.io.openliberty.guides.inventory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
 import jakarta.json.JsonObject;
-import jakarta.net.ssl.HostnameVerifier;
-import jakarta.net.ssl.SSLSession;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MediaType;

--- a/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package it.io.openliberty.guides.inventory;

--- a/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -23,7 +23,6 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -58,7 +57,6 @@ public class InventoryEndpointIT {
                     })
                     .build();
 
-        client.register(JsrJsonpProvider.class);
         client.target(invUrl + "reset").request().post(null);
     }
 
@@ -96,7 +94,7 @@ public class InventoryEndpointIT {
         int expected = 1;
         int actual = obj.getInt("total");
         assertEquals(expected, actual,
-                "The inventory should have one entry for the system service:"
+                "The inventory should have one entry for the system service: "
                     + sysKubeService);
 
         boolean serviceExists = obj.getJsonArray("systems").getJsonObject(0)

--- a/finish/kubernetes.yaml
+++ b/finish/kubernetes.yaml
@@ -42,7 +42,7 @@ spec:
         image: gcr.io/[project-id]/inventory:1.0-SNAPSHOT
         # end::invImage[]
         ports:
-        - containerPort: 9080
+        - containerPort: 9081
 ---
 apiVersion: v1
 kind: Service
@@ -72,6 +72,6 @@ spec:
     app: inventory
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9081
+    targetPort: 9081
     nodePort: 32000

--- a/finish/system/Dockerfile
+++ b/finish/system/Dockerfile
@@ -1,4 +1,4 @@
-FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+FROM icr.io/appcafe/open-liberty:kernel-slim-java11-openj9-ubi
 
 ARG VERSION=1.0
 ARG REVISION=SNAPSHOT
@@ -17,6 +17,6 @@ LABEL \
   description="This image contains the system microservice running with the Open Liberty runtime."
 
 COPY --chown=1001:0 src/main/liberty/config /config/
+RUN features.sh
 COPY --chown=1001:0 target/system.war /config/apps
-
 RUN configure.sh

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -20,8 +20,8 @@
         <cluster.ip>localhost</cluster.ip>
         <system.node.port>31000</system.node.port>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.3</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -72,19 +72,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <cluster.ip>${cluster.ip}</cluster.ip>

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -47,15 +47,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-client</artifactId>
-            <version>3.3.6</version>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-extension-providers</artifactId>
-            <version>3.3.6</version>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/finish/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,8 @@
 package io.openliberty.guides.system;
 
 // JAX-RS
-import javax.ws.rs.core.Application;
-import javax.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
 
 @ApplicationPath("system")
 public class SystemApplication extends Application {

--- a/finish/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package io.openliberty.guides.system;

--- a/finish/system/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,13 +13,13 @@
 package io.openliberty.guides.system;
 
 // CDI
-import javax.enterprise.context.RequestScoped;
-import javax.ws.rs.GET;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.GET;
 // JAX-RS
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @RequestScoped
 @Path("/properties")
@@ -31,5 +31,5 @@ public class SystemResource {
     return Response.ok(System.getProperties())
       .header("X-Pod-Name", System.getenv("HOSTNAME"))
       .build();
-  } 
+  }
 }

--- a/finish/system/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
  // end::copyright[]
 package io.openliberty.guides.system;

--- a/finish/system/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/finish/system/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
- // end::copyright[]
+// end::copyright[]
 package io.openliberty.guides.system;
 
 // CDI

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -2,14 +2,14 @@
 
   <featureManager>
     <feature>jaxrs-2.1</feature>
-    <feature>jsonp-1.1</feature>
-    <feature>cdi-2.0</feature>
+    <feature>jsonp-2.1</feature>
+    <feature>cdi-4.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />
 
   <webApplication location="system.war" contextRoot="/"/>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -1,8 +1,9 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-    <feature>jaxrs-2.1</feature>
+    <feature>restfulWS-3.1</feature>
     <feature>jsonp-2.1</feature>
+    <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
   </featureManager>
 

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -32,8 +32,9 @@
         <ul>
             <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 4.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#jaxrs-2.1.html" target="_blank" rel="noopener noreferrer">Java RESTful Services 2.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 2.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
         </ul>
     </p>
 </div>

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2020 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -30,10 +30,10 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-3.3.html" target="_blank" rel="noopener noreferrer">MicroProfile 3.3</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#cdi-2.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 2.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jaxrs-2.1.html" target="_blank" rel="noopener noreferrer">Java RESTful Services 2.1</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-1.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 1.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 2.1</a></li>
         </ul>
     </p>
 </div>

--- a/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -65,7 +65,8 @@ public class SystemEndpointIT {
         WebTarget target = client.target(sysUrl);
         Response response = target.request().get();
 
-        assertEquals(200, response.getStatus(), "Incorrect response code from " + sysUrl);
+        assertEquals(200, response.getStatus(), "Incorrect response code from "
+                     + sysUrl);
         response.close();
     }
 

--- a/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -21,7 +21,6 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 
-import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -60,7 +59,6 @@ public class SystemEndpointIT {
     @Test
     public void testGetProperties() {
         Client client = ClientBuilder.newClient();
-        client.register(JsrJsonpProvider.class);
 
         WebTarget target = client.target(sysUrl);
         Response response = target.request().get();

--- a/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,12 +14,12 @@ package it.io.openliberty.guides.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSession;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
+import jakarta.net.ssl.HostnameVerifier;
+import jakarta.net.ssl.SSLSession;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
 import org.junit.jupiter.api.AfterEach;
@@ -41,7 +41,7 @@ public class SystemEndpointIT {
 
         sysUrl = "http://" + clusterIp + ":" + sysNodePort + "/system/properties/";
     }
-    
+
     @BeforeEach
     public void setup() {
         response = null;
@@ -70,5 +70,5 @@ public class SystemEndpointIT {
         assertEquals(200, response.getStatus(), "Incorrect response code from " + sysUrl);
         response.close();
     }
-    
+
 }

--- a/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,13 +1,11 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package it.io.openliberty.guides.system;

--- a/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -13,8 +13,9 @@ package it.io.openliberty.guides.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import jakarta.net.ssl.HostnameVerifier;
-import jakarta.net.ssl.SSLSession;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
@@ -31,7 +32,6 @@ public class SystemEndpointIT {
     private static String sysUrl;
 
     private Client client;
-    private Response response;
 
     @BeforeAll
     public static void oneTimeSetup() {
@@ -43,7 +43,6 @@ public class SystemEndpointIT {
 
     @BeforeEach
     public void setup() {
-        response = null;
         client = ClientBuilder.newBuilder()
                     .hostnameVerifier(new HostnameVerifier() {
                         public boolean verify(String hostname, SSLSession session) {

--- a/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/finish/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,5 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/scripts/dailyBuild.sh
+++ b/scripts/dailyBuild.sh
@@ -15,7 +15,7 @@ echo "Testing daily OpenLiberty image"
 sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#a<configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/""$DATE""/""$DRIVER""</runtimeUrl></install></configuration>" system/pom.xml inventory/pom.xml
 cat system/pom.xml inventory/pom.xml
 
-sed -i "s;FROM openliberty/open-liberty:kernel-java8-openj9-ubi;FROM ""$DOCKER_USERNAME""/olguides:""$BUILD"";g" inventory/Dockerfile system/Dockerfile
+sed -i "s;FROM icr.io/appcafe/open-liberty:kernel-slim-java11-openj9-ubi;FROM ""$DOCKER_USERNAME""/olguides:""$BUILD"";g" inventory/Dockerfile system/Dockerfile
 cat inventory/Dockerfile system/Dockerfile
 
 docker pull "$DOCKER_USERNAME""/olguides:""$BUILD"

--- a/scripts/dockerImageTest.sh
+++ b/scripts/dockerImageTest.sh
@@ -13,7 +13,7 @@ echo "Test latest OpenLiberty Docker image"
 sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#a<configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/""$DATE""/""$DRIVER""</runtimeUrl></install></configuration>" system/pom.xml inventory/pom.xml
 cat system/pom.xml inventory/pom.xml
 
-sed -i "s;FROM openliberty/open-liberty:kernel-java8-openj9-ubi;FROM cp.stg.icr.io/cp/olc/open-liberty-daily:full-java11-openj9-ubi;g" inventory/Dockerfile system/Dockerfile
+sed -i "s;FROM icr.io/appcafe/open-liberty:kernel-slim-java11-openj9-ubi;FROM cp.stg.icr.io/cp/olc/open-liberty-daily:full-java11-openj9-ubi;g" inventory/Dockerfile system/Dockerfile
 cat inventory/Dockerfile system/Dockerfile
 
 echo "$DOCKER_PASSWORD" | sudo -u runner docker login -u "$DOCKER_USERNAME" --password-stdin cp.stg.icr.io

--- a/scripts/test.yaml
+++ b/scripts/test.yaml
@@ -64,6 +64,6 @@ spec:
     app: inventory
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9081
+    targetPort: 9081
     nodePort: 32000

--- a/scripts/testAppLocal.sh
+++ b/scripts/testAppLocal.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euxo pipefail
+
+mvn -ntp -pl system -Dhttp.keepAlive=false \
+    -Dmaven.wagon.http.pool=false \
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 \
+    -q clean package liberty:create liberty:install-feature liberty:deploy
+mvn -ntp -pl inventory -Dhttp.keepAlive=false \
+    -Dmaven.wagon.http.pool=false \
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 \
+    -q clean package liberty:create liberty:install-feature liberty:deploy
+
+mvn -ntp -pl system liberty:start
+mvn -ntp -pl inventory liberty:start
+
+mvn -ntp -pl system -Dhttp.keepAlive=false \
+    -Dmaven.wagon.http.pool=false \
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 \
+    -Dsystem.node.port=9080 \
+    failsafe:integration-test
+
+mvn -ntp -pl inventory -Dhttp.keepAlive=false \
+    -Dmaven.wagon.http.pool=false \
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 \
+    -Dsystem.node.port=9080 \
+    -Dinventory.node.port=9081 \
+    -Dsystem.kube.service=localhost \
+    failsafe:integration-test
+
+mvn -ntp -pl system liberty:stop
+mvn -ntp -pl inventory liberty:stop
+
+mvn -ntp failsafe:verify
+

--- a/start/inventory/Dockerfile
+++ b/start/inventory/Dockerfile
@@ -1,4 +1,4 @@
-FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+FROM icr.io/appcafe/open-liberty:kernel-slim-java11-openj9-ubi
 
 ARG VERSION=1.0
 ARG REVISION=SNAPSHOT
@@ -17,6 +17,6 @@ LABEL \
   description="This image contains the inventory microservice running with the Open Liberty runtime."
 
 COPY --chown=1001:0 src/main/liberty/config /config/
+RUN features.sh
 COPY --chown=1001:0 target/inventory.war /config/apps
-
 RUN configure.sh

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -30,8 +30,8 @@
         <inventory.node.port>32000</inventory.node.port>
         <!-- end::inventory-node-port[] -->
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.3</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -88,19 +88,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <cluster.ip>${cluster.ip}</cluster.ip>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -30,8 +30,8 @@
         <inventory.node.port>32000</inventory.node.port>
         <!-- end::inventory-node-port[] -->
         <!-- Liberty configuration -->
-        <liberty.var.http.port>9080</liberty.var.http.port>
-        <liberty.var.https.port>9443</liberty.var.https.port>
+        <liberty.var.http.port>9081</liberty.var.http.port>
+        <liberty.var.https.port>9444</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -57,21 +57,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-client</artifactId>
-            <version>3.3.6</version>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-extension-providers</artifactId>
-            <version>3.3.6</version>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1.4</version>
+            <artifactId>jakarta.json</artifactId>
+            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
  // end::copyright[]
 package io.openliberty.guides.inventory;

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,8 @@
 package io.openliberty.guides.inventory;
 
 // JAX-RS
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("inventory")
 public class InventoryApplication extends Application {

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryApplication.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
- // end::copyright[]
+// end::copyright[]
 package io.openliberty.guides.inventory;
 
 // JAX-RS

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Properties;
 import io.openliberty.guides.inventory.model.InventoryList;
 import io.openliberty.guides.inventory.model.SystemData;
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 // tag::ApplicationScoped[]
 @ApplicationScoped

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -1,13 +1,11 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package io.openliberty.guides.inventory;

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -1,5 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -17,15 +17,15 @@ import io.openliberty.guides.inventory.model.InventoryList;
 
 import java.util.Properties;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 
 @RequestScoped
 @Path("/systems")
@@ -45,7 +45,7 @@ public class InventoryResource {
     Properties props = systemClient.getProperties(hostname);
     if (props == null) {
       return Response.status(Response.Status.NOT_FOUND)
-                     .entity("{ \"error\" : \"Unknown hostname or the system service " 
+                     .entity("{ \"error\" : \"Unknown hostname or the system service "
                      + "may not be running on " + hostname + "\" }")
                      .build();
     }

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package io.openliberty.guides.inventory;

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -39,7 +39,8 @@ public class SystemClient {
 
   // Wrapper function that gets properties
   public Properties getProperties(String hostname) {
-    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(HTTP_PORT), SYSTEM_PROPERTIES);
+    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(HTTP_PORT),
+                          SYSTEM_PROPERTIES);
     Builder clientBuilder = buildClientBuilder(url);
     return getPropertiesHelper(clientBuilder);
   }

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -76,8 +76,8 @@ public class SystemClient {
       Builder builder = client.target(urlString).request();
       return builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     } catch (Exception e) {
-      System.err.println("Exception thrown while building the client: " +
-                         e.getMessage());
+      System.err.println("Exception thrown while building the client: "
+                         + e.getMessage());
       return null;
     }
   }
@@ -94,8 +94,8 @@ public class SystemClient {
     } catch (RuntimeException e) {
       System.err.println("Runtime exception: " + e.getMessage());
     } catch (Exception e) {
-      System.err.println("Exception thrown while invoking the request: " +
-                         e.getMessage());
+      System.err.println("Exception thrown while invoking the request: "
+                         + e.getMessage());
     }
     return null;
   }

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,15 +15,15 @@ package io.openliberty.guides.inventory.client;
 import java.net.URI;
 import java.util.Properties;
 
-import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Invocation.Builder;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -35,12 +35,12 @@ public class SystemClient {
   private final String PROTOCOL = "http";
 
   @Inject
-  @ConfigProperty(name = "default.http.port")
-  String DEFAULT_PORT;
+  @ConfigProperty(name = "http.port")
+  String HTTP_PORT;
 
   // Wrapper function that gets properties
   public Properties getProperties(String hostname) {
-    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(DEFAULT_PORT), SYSTEM_PROPERTIES);
+    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(HTTP_PORT), SYSTEM_PROPERTIES);
     Builder clientBuilder = buildClientBuilder(url);
     return getPropertiesHelper(clientBuilder);
   }

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package io.openliberty.guides.inventory.client;

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -34,12 +34,12 @@ public class SystemClient {
   private final String PROTOCOL = "http";
 
   @Inject
-  @ConfigProperty(name = "http.port")
-  String HTTP_PORT;
+  @ConfigProperty(name = "system.node.port")
+  String SYS_NODE_PORT;
 
   // Wrapper function that gets properties
   public Properties getProperties(String hostname) {
-    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(HTTP_PORT),
+    String url = buildUrl(PROTOCOL, hostname, Integer.valueOf(SYS_NODE_PORT),
                           SYSTEM_PROPERTIES);
     Builder clientBuilder = buildClientBuilder(url);
     return getPropertiesHelper(clientBuilder);

--- a/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/inventory/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -76,7 +76,8 @@ public class SystemClient {
       Builder builder = client.target(urlString).request();
       return builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     } catch (Exception e) {
-      System.err.println("Exception thrown while building the client: " + e.getMessage());
+      System.err.println("Exception thrown while building the client: " +
+                         e.getMessage());
       return null;
     }
   }
@@ -93,7 +94,8 @@ public class SystemClient {
     } catch (RuntimeException e) {
       System.err.println("Runtime exception: " + e.getMessage());
     } catch (Exception e) {
-      System.err.println("Exception thrown while invoking the request: " + e.getMessage());
+      System.err.println("Exception thrown while invoking the request: " +
+                         e.getMessage());
     }
     return null;
   }

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -2,15 +2,15 @@
 
   <featureManager>
     <feature>jaxrs-2.1</feature>
-    <feature>jsonp-1.1</feature>
-    <feature>mpConfig-1.4</feature>
-    <feature>cdi-2.0</feature>
+    <feature>jsonp-2.1</feature>
+    <feature>mpConfig-3.1</feature>
+    <feature>cdi-4.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />
 
   <webApplication location="inventory.war" contextRoot="/"/>

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -1,14 +1,16 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-    <feature>jaxrs-2.1</feature>
+    <feature>restfulWS-3.1</feature>
     <feature>jsonp-2.1</feature>
-    <feature>mpConfig-3.1</feature>
+    <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
+    <feature>mpConfig-3.1</feature>
   </featureManager>
 
-  <variable name="http.port" defaultValue="9080"/>
-  <variable name="https.port" defaultValue="9443"/>
+  <variable name="system.node.port" defaultValue="9080"/>
+  <variable name="http.port" defaultValue="9081"/>
+  <variable name="https.port" defaultValue="9444"/>
 
   <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />

--- a/start/inventory/src/main/webapp/index.html
+++ b/start/inventory/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2020 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/start/inventory/src/main/webapp/index.html
+++ b/start/inventory/src/main/webapp/index.html
@@ -33,8 +33,9 @@
             <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 4.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#jaxrs-2.1.html" target="_blank" rel="noopener noreferrer">Java RESTful Services 2.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 2.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
         </ul>
     </p>
 </div>

--- a/start/inventory/src/main/webapp/index.html
+++ b/start/inventory/src/main/webapp/index.html
@@ -30,11 +30,11 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-3.3.html" target="_blank" rel="noopener noreferrer">MicroProfile 3.3</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-1.4.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 1.4</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#cdi-2.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 2.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jaxrs-2.1.html" target="_blank" rel="noopener noreferrer">Java RESTful Services 2.1</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-1.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 1.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 2.1</a></li>
         </ul>
     </p>
 </div>

--- a/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,13 +15,13 @@ package it.io.openliberty.guides.inventory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.json.JsonObject;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSession;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.json.JsonObject;
+import jakarta.net.ssl.HostnameVerifier;
+import jakarta.net.ssl.SSLSession;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
 import org.junit.jupiter.api.AfterAll;

--- a/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -117,10 +117,10 @@ public class InventoryEndpointIT {
         this.assertResponse(sysUrl, sysResponse);
 
         JsonObject jsonFromInventory = (JsonObject) invResponse
-                                                            .readEntity(JsonObject.class)
-                                                            .getJsonArray("systems")
-                                                            .getJsonObject(0)
-                                                            .get("properties");
+                                                    .readEntity(JsonObject.class)
+                                                    .getJsonArray("systems")
+                                                    .getJsonObject(0)
+                                                    .get("properties");
 
         JsonObject jsonFromSystem = sysResponse.readEntity(JsonObject.class);
 

--- a/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -14,9 +14,10 @@ package it.io.openliberty.guides.inventory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
 import jakarta.json.JsonObject;
-import jakarta.net.ssl.HostnameVerifier;
-import jakarta.net.ssl.SSLSession;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MediaType;

--- a/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package it.io.openliberty.guides.inventory;

--- a/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -23,7 +23,6 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -58,7 +57,6 @@ public class InventoryEndpointIT {
                     })
                     .build();
 
-        client.register(JsrJsonpProvider.class);
         client.target(invUrl + "reset").request().post(null);
     }
 
@@ -96,7 +94,7 @@ public class InventoryEndpointIT {
         int expected = 1;
         int actual = obj.getInt("total");
         assertEquals(expected, actual,
-                "The inventory should have one entry for the system service:"
+                "The inventory should have one entry for the system service: "
                     + sysKubeService);
 
         boolean serviceExists = obj.getJsonArray("systems").getJsonObject(0)

--- a/start/kubernetes.yaml
+++ b/start/kubernetes.yaml
@@ -38,7 +38,7 @@ spec:
       - name: inventory-container
         image: gcr.io/[project-id]/inventory:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9081
 ---
 apiVersion: v1
 kind: Service
@@ -64,6 +64,6 @@ spec:
     app: inventory
   ports:
   - protocol: TCP
-    port: 9080
-    targetPort: 9080
+    port: 9081
+    targetPort: 9081
     nodePort: 32000

--- a/start/system/Dockerfile
+++ b/start/system/Dockerfile
@@ -1,4 +1,4 @@
-FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+FROM icr.io/appcafe/open-liberty:kernel-slim-java11-openj9-ubi
 
 ARG VERSION=1.0
 ARG REVISION=SNAPSHOT
@@ -17,6 +17,6 @@ LABEL \
   description="This image contains the system microservice running with the Open Liberty runtime."
 
 COPY --chown=1001:0 src/main/liberty/config /config/
+RUN features.sh
 COPY --chown=1001:0 target/system.war /config/apps
-
 RUN configure.sh

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -20,8 +20,8 @@
         <cluster.ip>localhost</cluster.ip>
         <system.node.port>31000</system.node.port>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>3.3</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -72,19 +72,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <cluster.ip>${cluster.ip}</cluster.ip>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -47,15 +47,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-client</artifactId>
-            <version>3.3.6</version>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-rt-rs-extension-providers</artifactId>
-            <version>3.3.6</version>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/start/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,8 @@
 package io.openliberty.guides.system;
 
 // JAX-RS
-import javax.ws.rs.core.Application;
-import javax.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
 
 @ApplicationPath("system")
 public class SystemApplication extends Application {

--- a/start/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/SystemApplication.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package io.openliberty.guides.system;

--- a/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,13 +13,13 @@
 package io.openliberty.guides.system;
 
 // CDI
-import javax.enterprise.context.RequestScoped;
-import javax.ws.rs.GET;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.GET;
 // JAX-RS
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 @RequestScoped
 @Path("/properties")
@@ -31,5 +31,5 @@ public class SystemResource {
     return Response.ok(System.getProperties())
       .header("X-Pod-Name", System.getenv("HOSTNAME"))
       .build();
-  } 
+  }
 }

--- a/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
  // end::copyright[]
 package io.openliberty.guides.system;

--- a/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
- // end::copyright[]
+// end::copyright[]
 package io.openliberty.guides.system;
 
 // CDI

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -2,14 +2,14 @@
 
   <featureManager>
     <feature>jaxrs-2.1</feature>
-    <feature>jsonp-1.1</feature>
-    <feature>cdi-2.0</feature>
+    <feature>jsonp-2.1</feature>
+    <feature>cdi-4.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9080"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />
 
   <webApplication location="system.war" contextRoot="/"/>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -1,8 +1,9 @@
 <server description="Sample Liberty server">
 
   <featureManager>
-    <feature>jaxrs-2.1</feature>
+    <feature>restfulWS-3.1</feature>
     <feature>jsonp-2.1</feature>
+    <feature>jsonb-3.0</feature>
     <feature>cdi-4.0</feature>
   </featureManager>
 

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -32,8 +32,9 @@
         <ul>
             <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 4.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#jaxrs-2.1.html" target="_blank" rel="noopener noreferrer">Java RESTful Services 2.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 2.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
         </ul>
     </p>
 </div>

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2020 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -30,10 +30,10 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-3.3.html" target="_blank" rel="noopener noreferrer">MicroProfile 3.3</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#cdi-2.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 2.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jaxrs-2.1.html" target="_blank" rel="noopener noreferrer">Java RESTful Services 2.1</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-1.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 1.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">JavaScript Object Notation Processing 2.1</a></li>
         </ul>
     </p>
 </div>

--- a/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -2,12 +2,11 @@
 /*******************************************************************************
  * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package it.io.openliberty.guides.system;

--- a/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -21,7 +21,6 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 
-import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -60,7 +59,6 @@ public class SystemEndpointIT {
     @Test
     public void testGetProperties() {
         Client client = ClientBuilder.newClient();
-        client.register(JsrJsonpProvider.class);
 
         WebTarget target = client.target(sysUrl);
         Response response = target.request().get();

--- a/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,12 +14,12 @@ package it.io.openliberty.guides.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLSession;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
+import jakarta.net.ssl.HostnameVerifier;
+import jakarta.net.ssl.SSLSession;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
 import org.junit.jupiter.api.AfterEach;
@@ -41,7 +41,7 @@ public class SystemEndpointIT {
 
         sysUrl = "http://" + clusterIp + ":" + sysNodePort + "/system/properties/";
     }
-    
+
     @BeforeEach
     public void setup() {
         response = null;
@@ -70,5 +70,5 @@ public class SystemEndpointIT {
         assertEquals(200, response.getStatus(), "Incorrect response code from " + sysUrl);
         response.close();
     }
-    
+
 }

--- a/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -66,7 +66,8 @@ public class SystemEndpointIT {
         WebTarget target = client.target(sysUrl);
         Response response = target.request().get();
 
-        assertEquals(200, response.getStatus(), "Incorrect response code from " + sysUrl);
+        assertEquals(200, response.getStatus(), "Incorrect response code from "
+                     + sysUrl);
         response.close();
     }
 

--- a/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/start/system/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -13,8 +13,9 @@ package it.io.openliberty.guides.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import jakarta.net.ssl.HostnameVerifier;
-import jakarta.net.ssl.SSLSession;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.WebTarget;
@@ -31,7 +32,6 @@ public class SystemEndpointIT {
     private static String sysUrl;
 
     private Client client;
-    private Response response;
 
     @BeforeAll
     public static void oneTimeSetup() {
@@ -43,7 +43,6 @@ public class SystemEndpointIT {
 
     @BeforeEach
     public void setup() {
-        response = null;
         client = ClientBuilder.newBuilder()
                     .hostnameVerifier(new HostnameVerifier() {
                         public boolean verify(String hostname, SSLSession session) {


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

